### PR TITLE
fix vx_m4 issue #31

### DIFF
--- a/src/vix_utils/download_vix_futures.py
+++ b/src/vix_utils/download_vix_futures.py
@@ -162,7 +162,7 @@ def generate_monthly_url_dates():
      """
      Returns  the possible monthly urls and the date strings for all years and months in the default range.
      """
-     return (generate_monthly_url_date(y,m) for y,m in years_and_months)
+     return (generate_monthly_url_date(y,m) for y,m in years_and_months())
 
 def generate_weekly_url_date(date):
     """

--- a/src/vix_utils/vix_futures_dates.py
+++ b/src/vix_utils/vix_futures_dates.py
@@ -81,7 +81,7 @@ def vix_futures_expiry_date_monthly(year: int, month: int):
 
     futures_expiry_date = option_expiry_date - dt.timedelta(days=30)
     # also check for a holiday on the 30 days before the 3d friday
-    if friday_expiration and not any(_valid_cfe_days.isin([option_expiry_date])):
+    if friday_expiration and not any(_valid_cfe_days.isin([futures_expiry_date])):
         futures_expiry_date = futures_expiry_date - dt.timedelta(days=1)
 
     return futures_expiry_date


### PR DESCRIPTION
- fix vix_futures_expiry_date_monthly
- fix generate_monthly_url_dates, the generator was missing "()"

Before fix for #31

```python
vu.vix_futures_dates.vix_futures_expiry_date_monthly(2024,6)
datetime.date(2024, 6, 19)
```

after fix
```python
vu.vix_futures_dates.vix_futures_expiry_date_monthly(2024,6)
datetime.date(2024, 6, 18)
```